### PR TITLE
[BRIDGE-23] Fix event publisher

### DIFF
--- a/application/services/event_publisher.py
+++ b/application/services/event_publisher.py
@@ -36,8 +36,8 @@ class EventPublisher:
                         "logIndex": event.log_index,
                         "error_code": event.error_code,
                         "error_msg": event.error_msg,
-                        "row_updated": event.updated_at,
-                        "row_created": event.created_at,
+                        "row_updated": str(event.updated_at),
+                        "row_created": str(event.created_at),
                     },
                     "name": event.event_name
                 }


### PR DESCRIPTION
Fix error:
```
[ERROR] TypeError: Object of type datetime is not JSON serializable
Traceback (most recent call last):
  File "/var/task/application/handlers/event_publisher_handler.py", line 14, in publish_events
    EventPublisher().manage_publish_events()
  File "/var/task/application/services/event_publisher.py", line 21, in manage_publish_events
    self.publish_event(topic.arn, events)
  File "/var/task/application/services/event_publisher.py", line 47, in publish_event
    response = boto_util.publish_to_sns_topic(arn, payload, message_group_id, message_deduplication_id)
  File "/var/task/common/boto_utils.py", line 38, in publish_to_sns_topic
    Message=json.dumps({'default': json.dumps(payload)}),
  File "/var/lang/lib/python3.7/json/init.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/var/lang/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/var/lang/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/var/lang/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.class.name} '
```