### PR TITLE
[bridge-24] fix publish message in SNS

### DIFF
--- a/application/services/event_publisher.py
+++ b/application/services/event_publisher.py
@@ -42,9 +42,7 @@ class EventPublisher:
                     "name": event.event_name
                 }
             }
-            message_group_id = event.event_name
-            message_deduplication_id = str(event.id)
-            response = boto_util.publish_to_sns_topic(arn, payload, message_group_id, message_deduplication_id)
+            response = boto_util.publish_to_sns_topic(arn, payload)
             if response["ResponseMetadata"]["HTTPStatusCode"] == 200:
                 EventRepository().mark_event_as_processed(event_id=event.id)
             else:

--- a/common/boto_utils.py
+++ b/common/boto_utils.py
@@ -31,13 +31,11 @@ class BotoUtils:
             return lambda_response
         return json.loads(lambda_response.get('Payload').read())
 
-    def publish_to_sns_topic(self, arn, payload, message_group_id, message_deduplication_id):
+    def publish_to_sns_topic(self, arn, payload):
         client = boto3.client('sns', region_name=self.region_name)
         response = client.publish(
             TargetArn=arn,
             Message=json.dumps({'default': json.dumps(payload)}),
-            MessageStructure='json',
-            MessageGroupId=message_group_id,
-            MessageDeduplicationId=message_deduplication_id
+            MessageStructure='json'
         )
         return response


### PR DESCRIPTION
Fix error:
<details>
<summary><b>Error description</b></summary>

```
[ERROR] InvalidParameterException: An error occurred (InvalidParameter) when calling the Publish operation: Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type
Traceback (most recent call last):
  File "/var/task/application/handlers/event_publisher_handler.py", line 14, in publish_events
    EventPublisher().manage_publish_events()
  File "/var/task/application/services/event_publisher.py", line 21, in manage_publish_events
    self.publish_event(topic.arn, events)
  File "/var/task/application/services/event_publisher.py", line 47, in publish_event
    response = boto_util.publish_to_sns_topic(arn, payload, message_group_id, message_deduplication_id)
  File "/var/task/common/boto_utils.py", line 41, in publish_to_sns_topic
    MessageDeduplicationId=message_deduplication_id
  File "/var/task/botocore/client.py", line 415, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/task/botocore/client.py", line 745, in _make_api_call
    raise error_class(parsed_response, operation_name)
```

</details>
